### PR TITLE
spirv: don't generate union tag type if it doesnt exist

### DIFF
--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -1116,21 +1116,20 @@ pub const DeclGen = struct {
             return self.todo("packed union types", .{});
         }
 
-        const tag_ty_ref = try self.resolveType(union_ty.tag_ty, .indirect);
         if (layout.payload_size == 0) {
             // No payload, so represent this as just the tag type.
-            return tag_ty_ref;
+            return try self.resolveType(union_ty.tag_ty, .indirect);
         }
 
         var members = std.BoundedArray(SpvType.Payload.Struct.Member, 4){};
 
         const has_tag = layout.tag_size != 0;
         const tag_first = layout.tag_align >= layout.payload_align;
-        const tag_member = .{ .name = "tag", .ty = tag_ty_ref };
         const u8_ty_ref = try self.intType(.unsigned, 8); // TODO: What if Int8Type is not enabled?
 
         if (has_tag and tag_first) {
-            members.appendAssumeCapacity(tag_member);
+            const tag_ty_ref = try self.resolveType(union_ty.tag_ty, .indirect);
+            members.appendAssumeCapacity(.{ .name = "tag", .ty = tag_ty_ref });
         }
 
         const active_field = maybe_active_field orelse layout.most_aligned_field;
@@ -1149,7 +1148,8 @@ pub const DeclGen = struct {
         }
 
         if (has_tag and !tag_first) {
-            members.appendAssumeCapacity(tag_member);
+            const tag_ty_ref = try self.resolveType(union_ty.tag_ty, .indirect);
+            members.appendAssumeCapacity(.{ .name = "tag", .ty = tag_ty_ref });
         }
 
         if (layout.padding != 0) {


### PR DESCRIPTION
Previously the tag type was generated even if it was nonexistant, triggering an assertion that an integer type should never have zero bits. Now its only generated when the tag type is actually emitted.